### PR TITLE
fix: error "cache directory not exist" at first train run

### DIFF
--- a/main.py
+++ b/main.py
@@ -161,6 +161,7 @@ if __name__ == "__main__":
 
         savePath = join(logdir, opt.savePath)
         makedirs(savePath)
+        makedirs(opt.cachePath)
 
         with open(join(savePath, 'flags.json'), 'w') as f:
             f.write(json.dumps({k:v for k,v in opt.items()}))


### PR DESCRIPTION
Running training script as described in README.md now returns following error:
```
Traceback (most recent call last):
  File "main.py", line 172, in <module>
    train(opt, model, encoder_dim, device, dataset, criterion, optimizer, train_set, whole_train_set, whole_training_data_loader, epoch, writer)
  File "/home/docker_seqmatchnet/SeqMatchNet/train.py", line 32, in train
    with h5py.File(train_set.cache, mode='w') as h5:
  File "/opt/conda/lib/python3.8/site-packages/h5py/_hl/files.py", line 406, in __init__
    fid = make_fid(name, mode, userblock_size,
  File "/opt/conda/lib/python3.8/site-packages/h5py/_hl/files.py", line 179, in make_fid
    fid = h5f.create(name, h5f.ACC_TRUNC, fapl=fapl, fcpl=fcpl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5f.pyx", line 108, in h5py.h5f.create
OSError: Unable to create file (unable to open file: name = './data/cache/train_feat_cache_Mar28_14-34-28_l5_ox10_MoP_negMoP.hdf5', errno = 2, error message = 'No such file or directory', flags = 13, o_flags = 242)
```

This PR fixes that issue by simply creating cache directory before accessing it.