### PR TITLE
fix: restoring saved flags error and resuming wandb session in test mode disabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     if not opt.pooling and opt.resume:
         raise Exception("Please run without the '--resume' argument when '--pooling' is not used.")
 
-    if opt.resume:
+    if opt.resume and not opt.mode == 'test':
         flag_file = join(opt.resume, 'checkpoints', 'flags.json')
         if exists(flag_file):
             with open(flag_file, 'r') as f:
@@ -103,7 +103,7 @@ if __name__ == "__main__":
                 opt = parser.parse_args(train_flags, namespace=opt)
 
     wandb_dataStr = opt.dataset.lower()[:4]
-    wandbResume = False if opt.resume == '' else True
+    wandbResume = False if (opt.resume == '') or (opt.mode == 'test') else True
     wandb.init(project='SeqMatchNet_{}'.format(wandb_dataStr),config=opt,resume=wandbResume)
     # update runName
     runName = wandb.run.name


### PR DESCRIPTION
- "following arguments are required" error:
 Running testing script as described in README.md now returns following error:
  ```
  $ python main.py --mode test --seqL 5 --pooling --dataset oxford-v1.0 --split test --resume ./data/runs/Mar28_12-31-26_l5_ox10_MoP_negMoP
  Restored flags: ['--optim', 'SGD', '--lr', '0.001', '--lrStep', '5', '--lrGamma', '0.5', '--weightDecay', '0.001', '--momentum', '0.9', '--seed', '123', '--patience', '0', '--runsPath', './data/runs', '--savePath', 'checkpoints', '--outDims', '4096', '--margin', '0.1']
  usage: main.py [-h] --mode {train,test} [--batchSize BATCHSIZE] [--cacheBatchSize CACHEBATCHSIZE] [--cacheRefreshRate CACHEREFRESHRATE] [--nEpochs NEPOCHS] [--start-epoch N]
                 [--nGPU NGPU] [--optim {SGD,ADAM}] [--lr LR] [--lrStep LRSTEP] [--lrGamma LRGAMMA] [--weightDecay WEIGHTDECAY] [--momentum MOMENTUM] [--nocuda] [--threads THREADS]
                 [--seed SEED] [--patience PATIENCE] [--evalEvery EVALEVERY] [--expName EXPNAME] [--runsPath RUNSPATH] [--savePath SAVEPATH] [--cachePath CACHEPATH]
                 [--resultsPath RESULTSPATH] [--resume RESUME] [--ckpt {latest,best}] [--split {test,train,val}] [--numSamples2Project NUMSAMPLES2PROJECT] [--extractOnly]
                 [--predictionsFile PREDICTIONSFILE] [--seqL_filterData SEQL_FILTERDATA] --dataset {nordland-sw,nordland-sf,oxford-v1.0,oxford-pnv} [--pooling] --seqL SEQL
                 [--outDims OUTDIMS] [--margin MARGIN] [--descType DESCTYPE] [--matcher {seqMatchNet,None}] [--loss_trip_method {centerOnly,meanOfPairs}]
                 [--neg_trip_method {centerOnly,meanOfPairs}]
  main.py: error: the following arguments are required: --mode, --dataset, --seqL
  ```
  
  This is because of restoring flags from `flags.json` when `opt.resume == True` deletes all previously passed arguments.
  While I did not tried to fix restoring arguments in training mode, this PR simply fixes this error in test mode by disabling restoring flags if `opt.mode == 'test'`.

- wandb resuming in test mode error:
 Starting test script now results in incorrect attempt to resume non-existing wandb session. This PR fixes that issue if `opt.mode == 'test'`